### PR TITLE
add finalized and initialize methods to lib

### DIFF
--- a/pkcs11/_pkcs11.pyx
+++ b/pkcs11/_pkcs11.pyx
@@ -1355,6 +1355,14 @@ cdef class lib:
         except StopIteration:
             return token
 
+    def finalize(self):
+        if _funclist != NULL:
+            assertRV(_funclist.C_Finalize(NULL))
+
+    def initialize(self):
+        if _funclist != NULL:
+            assertRV(_funclist.C_Initialize(NULL))
+            
     def __dealloc__(self):
         if _funclist != NULL:
             assertRV(_funclist.C_Finalize(NULL))


### PR DESCRIPTION
I found that I need manual control over the C_Finalize/C_Initialize methods due to some finicky underlying PKCS11 module.